### PR TITLE
fix error metric_evaluator.py

### DIFF
--- a/src/metrics/metric_evaluator.py
+++ b/src/metrics/metric_evaluator.py
@@ -35,7 +35,15 @@ class MetricEvaluator:
         tqdm.pandas(desc='Evaluating metrics')
         for metric in tqdm(self.metrics, desc='Evaluating metrics'):
             generator = self.tags_generator[metric]()
-            df.loc[:, metric] = df.progress_apply(
-                lambda r: generator.evaluate_single_test_metric(r[target], r[predictions]),
-                axis=1)
+
+            if metric == 'tuple_order':
+                df.loc[:, metric] = None
+                mask = df['sql_tags'].str.contains('ORDERBY')
+                df.loc[mask, metric] = df[mask].progress_apply(
+                    lambda r: generator.evaluate_single_test_metric(r[target], r[predictions]),
+                    axis=1)
+            else:
+                df.loc[:, metric] = df.progress_apply(
+                    lambda r: generator.evaluate_single_test_metric(r[target], r[predictions]),
+                    axis=1)
         return df


### PR DESCRIPTION
* previous versions calculate tuple order by hand when calling the evaluator. New verision of the code this phenomena is handled by evaluate_with_df