### PR TITLE
Fix table validation and tag metrics calculation.

### DIFF
--- a/qatch/metrics/abstract_metric.py
+++ b/qatch/metrics/abstract_metric.py
@@ -34,17 +34,16 @@ class AbstractMetric(ABC):
     def is_table_well_structured(linearized_table: list[list]) -> bool:
         warning_output = ('Table should be a list of list:  [["wales", "scotland"], ["england"]].'
                           f' Returning zero')
-        try:
-            linearized_table = np.array(linearized_table)
-        except ValueError:
-            # This error is raised when the linearized_table does not have the correct structure: [[1,2,3], [[1],2,3]]
-            return False
 
-        # case where there is not the correct shape: [1,2,4] | [[[1], [2]]]
-        if len(linearized_table.shape) != 2:
-            logging.warning(warning_output)
-            return False
-
+        # the correct format must be a list of list [[1,2,3], [1,2,3]]
+        for value in linearized_table:
+            if not isinstance(value, list):
+                logging.warning(warning_output)
+                return False
+            for inner_value in value:
+                if not isinstance(inner_value, (str, float, int)):
+                    logging.warning(warning_output)
+                    return False
         return True
 
     def evaluate_single_test_metric(self,

--- a/qatch/metrics/cell_precision_tag.py
+++ b/qatch/metrics/cell_precision_tag.py
@@ -1,4 +1,4 @@
-import numpy as np
+from itertools import chain
 
 from .abstract_metric import AbstractMetric
 
@@ -38,8 +38,8 @@ class CellPrecisionTag(AbstractMetric):
             >>> evaluator.evaluate_single_no_special_case(target, prediction)
             1.0  # it is one even if the schema does not match (we introduce tuple constraints for this)
         """
-        target = np.array(target)
-        prediction = np.array(prediction)
-
-        sum_cell_match = np.sum(np.isin(prediction, target))
-        return round(sum_cell_match / prediction.size, 3)
+        target = set(chain.from_iterable(target))
+        prediction = set(chain.from_iterable(prediction))
+        intersected_cells = target.intersection(prediction)
+        sum_cell_match = len(intersected_cells)
+        return round(sum_cell_match / len(prediction), 3)

--- a/qatch/metrics/cell_recall_tag.py
+++ b/qatch/metrics/cell_recall_tag.py
@@ -1,4 +1,4 @@
-import numpy as np
+from itertools import chain
 
 from .abstract_metric import AbstractMetric
 
@@ -41,7 +41,8 @@ class CellRecallTag(AbstractMetric):
             >>> evaluator.evaluate_single_no_special_case(target, prediction)
             1.0
         """
-        target = np.array(target)
-        prediction = np.array(prediction)
-        sum_cell_match = np.sum(np.isin(target, prediction))
-        return round(sum_cell_match / target.size, 3)
+        target = set(chain.from_iterable(target))
+        prediction = set(chain.from_iterable(prediction))
+        intersected_cells = target.intersection(prediction)
+        sum_cell_match = len(intersected_cells)
+        return round(sum_cell_match / len(target), 3)


### PR DESCRIPTION
…ith poor formatted arrays [["wales", "scotland"], ["england"]]

* qatch/metrics/abstract_metric.py
  * refactor is_table_well_structured to use nested loop checks
  * remove numpy usage in is_table_well_structured

* qatch/metrics/cell_precision_tag.py
  * replace numpy with itertools.chain for set operations
  * refactor evaluate_single_no_special_case to use set intersections

* qatch/metrics/cell_recall_tag.py
  * replace numpy with itertools.chain for set operations
  * refactor evaluate_single_no_special_case to use set intersections